### PR TITLE
add url to entries

### DIFF
--- a/qml/components/DBEntry.qml
+++ b/qml/components/DBEntry.qml
@@ -111,6 +111,13 @@ UITK.ListItem {
                 text: passwordVisible ? password : '••••••••'
                 color: theme.palette.normal.backgroundTertiaryText
             }
+
+            Text {
+                text: url
+                width: parent.width
+                elide: Text.ElideRight
+                color: theme.palette.normal.backgroundTertiaryText
+            }
         }
     }
 

--- a/qml/components/DBEntry.qml
+++ b/qml/components/DBEntry.qml
@@ -112,6 +112,7 @@ UITK.ListItem {
                 width: parent.width
                 elide: Text.ElideRight
                 color: theme.palette.normal.backgroundTertiaryText
+                font.pixelSize: units.gu(1.5)
             }
 
             Text {

--- a/qml/components/DBEntry.qml
+++ b/qml/components/DBEntry.qml
@@ -6,7 +6,7 @@ import QtGraphicalEffects 1.0
 
 UITK.ListItem {
     property bool passwordVisible: false
-    height: units.gu(10)
+    height: units.gu(11)
     anchors.left: parent.left
     anchors.right: parent.right
 
@@ -108,14 +108,14 @@ UITK.ListItem {
             }
 
             Text {
-                text: passwordVisible ? password : '••••••••'
+                text: url
+                width: parent.width
+                elide: Text.ElideRight
                 color: theme.palette.normal.backgroundTertiaryText
             }
 
             Text {
-                text: url
-                width: parent.width
-                elide: Text.ElideRight
+                text: passwordVisible ? password : '••••••••'
                 color: theme.palette.normal.backgroundTertiaryText
             }
         }


### PR DESCRIPTION
Search does also search the url field. For example a search for "tt" will return most entries with an url since http/https contain this string.

BUT the url is not visible to the user. So I think this is confusing, since it is not obvious, why some entries are show as search results while the name does not contain the search string.

So I suggest to also show the url in the entries list. I made it elide, so long urls will be cut off on the right hand side if width is not sufficient.

This is the same behaviour as on Keepass desktop, so it should be fine. I would not remove the url from the search to fix this problem