### PR TITLE
Fix copying of password when username is absent

### DIFF
--- a/qml/components/DBEntry.qml
+++ b/qml/components/DBEntry.qml
@@ -46,7 +46,7 @@ UITK.ListItem {
                 }
             },
             UITK.Action {
-                visible: username
+                visible: password
                 iconSource: "../../assets/key.svg"
                 onTriggered: {
                     UITK.Clipboard.push(password)


### PR DESCRIPTION
It was not possible to copy password if DB entry did not have username.

Fix typo to show password button depending on the existence of password, not username.

Closes #28