### PR TITLE
Prepare for Focal builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ execute_process(
    OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 add_custom_target(no_idea ALL
-    COMMAND pip3 install -U pip==20.3.4 requests
+    COMMAND pip3 install -U pip requests
     COMMENT Building for ${CPU_ARCH}
     COMMAND pip3 install -U --platform ${CPU_ARCH} --only-binary=:all: pykeepass-rs==0.1.15 --target install/vendored
 )

--- a/Keepass.apparmor
+++ b/Keepass.apparmor
@@ -3,5 +3,5 @@
         "content_exchange",
         "networking"
     ],
-    "policy_version": 16.04
+    "policy_version": 20.04
 }

--- a/clickable.json
+++ b/clickable.json
@@ -1,9 +1,0 @@
-{
-  "clickable_minimum_required": "6.22.0",
-  "builder": "cmake",
-  "kill": "qmlscene",
-  "dependencies_host": [
-          "python3-pip",
-          "python3-wheel"
-  ]
-}

--- a/clickable.yaml
+++ b/clickable.yaml
@@ -1,0 +1,6 @@
+clickable_minimum_required: 7
+builder: cmake
+kill: qmlscene
+dependencies_host:
+- python3-pip
+- python3-wheel


### PR DESCRIPTION
PR follow up for #31 

I was able to build the click with `CLICKABLE_FRAMEWORK=ubuntu-sdk-20.04 clickable build --arch arm64`. But I still need to test it on a device running Focal. (Which I need to update yet)

After the branch is merged Xenial builds will no longer work. Maybe I should still keep the fixed pip version and set the policy version using an environment variable? This way you could still build for both OS versions.